### PR TITLE
Setting xaxis as 'category' so it won't skip weekends and closed market hours

### DIFF
--- a/app.py
+++ b/app.py
@@ -390,6 +390,7 @@ def history_view(tickers: Ticker, symbols: List[str], strings: dict):
                 low=dataframe['low'],
                 close=dataframe['close']
             ))
+            fig.layout.xaxis.type = 'category'
             st.plotly_chart(fig)
             
         st.dataframe(dataframe)


### PR DESCRIPTION
I'm pulling this *very* simple request so the xaxis will be treated as 'category', this will prevent the plotly figure of skipping weekends and closed market hours. The goal is to turn the figure into a continuous graph and get rid of these gaps.

![image](https://user-images.githubusercontent.com/18664907/83909511-4fb10180-a73f-11ea-8200-968d30425f67.png)

I couldn't test it myself because I don't know how to run streamlit apps locally xD, but I've tested this same parameter in other plotly graphs.